### PR TITLE
Update env name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Library for custom log formatting and other helpers leveraging Timbre.
 
 ```bash
 #export env variable to apply formatting
-ENABLE_LOG_FORMAT=anything
+ENABLE_LOGA=true
 ```
 
 **Repl**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# clj-loga
+# clj-loga [![Circle CI](https://circleci.com/gh/FundingCircle/clj-loga/tree/master.svg?style=svg)](https://circleci.com/gh/FundingCircle/clj-loga/tree/master)
+
 Library for custom log formatting and other helpers leveraging Timbre.
 
 ## Usage

--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,4 @@
                  ]
   :plugins [[lein-cljfmt  "0.3.0"]
             [lein-environ "1.0.1"]]
-  :profiles {:test {:env {:enable-log-format true}}})
+  :profiles {:test {:env {:enable-loga "true"}}})

--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -61,12 +61,12 @@
         append-tag
         generate-string)))
 
-(def ^:private disabled-formatter?
-  (nil? (env :enable-log-format)))
+(def ^:private loga-enabled?
+  (= (env :enable-loga) "true"))
 
 (defn init-logging []
   "Initialize formatted logging."
-  (if-not disabled-formatter?
+  (if loga-enabled?
     (do (timbre/handle-uncaught-jvm-exceptions!)
         (merge-config! {:output-fn output-fn
                         :timestamp-opts iso-timestamp-opts}))


### PR DESCRIPTION
Changes the variable name from `ENABLE_LOG_FORMAT` to `ENABLE_LOGA` for specificity.
Changes the expected env value from *anything* to *true*. This allows for disabling LOGA explicitly via the env variable, as oppose to using `unset`.