### PR TITLE
Use setup-loga to be more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ENABLE_LOGA=true
 (require '[clj-loga.core :refer [init-logging set-tag]])
 
 ;; initialize formatter
-(init-logging)
+(setup-loga)
 
 ;; easily log with timbre
 (timbre/info "Log it out.")

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-loga "0.1.0"
+(defproject clj-loga "0.2.0"
   :description "Library for custom log formatting and other helpers leveraging Timbre"
   :url "https://github.com/FundingCircle/clj-loga"
   :license {:name "Eclipse Public License"

--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -10,8 +10,8 @@
 
 (defmacro set-tag
   "Sets a tag, which is appended to the log event."
-  [tid* & body]
-  `(binding [_tag ~tid*] ~@body))
+  [tag* & body]
+  `(binding [_tag ~tag*] ~@body))
 
 (defn- get-tag []
   "Gets current _tag"
@@ -64,7 +64,7 @@
 (def ^:private loga-enabled?
   (= (env :enable-loga) "true"))
 
-(defn init-logging []
+(defn setup-loga []
   "Initialize formatted logging."
   (if loga-enabled?
     (do (timbre/handle-uncaught-jvm-exceptions!)

--- a/test/clj_loga/core_test.clj
+++ b/test/clj_loga/core_test.clj
@@ -6,7 +6,7 @@
             [taoensso.timbre :as timbre :refer [info]]))
 
 (defn- log-to-atom [f]
-  (init-logging)
+  (setup-loga)
   (timbre/merge-config! atom-appender)
   (f))
 
@@ -15,11 +15,13 @@
 (defn contains-expected-tags? [event]
   (every? #(get (parse-string event) (name %)) expected-default-tags))
 
-(deftest init-logging-test
-  (testing "contains desired defaut tags"
+(deftest setup-loga-test
+  (testing "formats log event to contain desired default tags"
     (info "A log event")
-    (is (true? (contains-expected-tags? @log-event))))
-  (testing "appends tag to the log"
+    (is (true? (contains-expected-tags? @log-event)))))
+
+(deftest set-tag-test
+  (testing "appends tag to the log event"
     (let [tag "the-tag"]
       (set-tag tag
                (info "A tagged dummy event"))


### PR DESCRIPTION
Replace `init-logging`, with more idiomatic `setup-loga`.