### PR TITLE
User can wrap related forms with tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ENABLE_LOGA=true
 **Repl**
 
 ```clojure
-(require '[clj-loga.core :refer [setup-loga set-log-tag operation-log-wrapper]])
+(require '[clj-loga.core :refer [setup-loga set-log-tag log-wrapper]])
 
 ;; initialize formatter
 (setup-loga)
@@ -33,16 +33,35 @@ ENABLE_LOGA=true
 ;; handle exceptions
 (timbre/error (Exception. "Something went wrong"))
 
-;; Related forms can be grouped as an operation (e.g. event processing) and wrapped around with a log messages.
-;; - macro *operation-log-wrapper* requires a map with a name of the operation e.g. {:operation "a-operation"}
+;; Related forms can be wrapped with log messages.
+;; - macro log-wrapper accepts a map with following keys:
 ;; - optional keys:
 ;;   - :tag - to tag log events
 ;;   - :pre-log-msg  - custom log message before body execution
 ;;   - :post-log-msg - custom log message after body execution
+;;   - :operation - descriptive name for the wrapped forms
 
-(operation-log-wrapper {:operation "processing message" :tag "smart-tag"}
-                         (do (prn "executing all the work") :return-value))
+:: custom basic application:
+(log-wrapper {:pre-log-msg "started processing kafka message"
+              :post-log-msg "finished processing kafka message"
+              :tag "message id"}
+              (do
+                (prn "all the work happening now")
+                "return value"))
 
+;; =>
+;; {"timestamp":"2015-12-31T11:25:57.598Z","level":"INFO","message":"started processing kafka message","namespace":"clj-loga.core","tag":"message id"}
+;; "all the work happening now"
+;; {"timestamp":"2015-12-31T11:25:57.599Z","level":"INFO","message":"finished processing kafka message","namespace":"clj-loga.core","tag":"message id"}
+
+;; or use defaults:
+(log-wrapper {:operation "processing message" :tag "smart-tag"}
+             (do (prn "executing all the work") :return-value))
+
+;; =>
+;; {"timestamp":"2015-12-31T11:19:28.146Z","level":"INFO","message":"started: processing message","namespace":"clj-loga.core","tag":"some-tag"}
+;; '"all the work happening now"
+;; {"timestamp":"2015-12-31T11:19:28.150Z","level":"INFO","message":"finished: processing message","namespace":"clj-loga.core","tag":"some-tag"}
 ```
 
 ## Features in progress

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ENABLE_LOGA=true
 **Repl**
 
 ```clojure
-(require '[clj-loga.core :refer [setup-loga set-tag]])
+(require '[clj-loga.core :refer [setup-loga set-log-tag operation-log-wrapper]])
 
 ;; initialize formatter
 (setup-loga)
@@ -27,11 +27,22 @@ ENABLE_LOGA=true
 (timbre/info "Log it out.")
 
 ;; tag logs
-(set-tag "smart-tag"
+(set-log-tag "smart-tag"
            (timbre/info "Log it tagged."))
 
 ;; handle exceptions
 (timbre/error (Exception. "Something went wrong"))
+
+;; Related forms can be grouped as an operation (e.g. event processing) and wrapped around with a log messages.
+;; - macro *operation-log-wrapper* requires a map with a name of the operation e.g. {:operation "a-operation"}
+;; - optional keys:
+;;   - :tag - to tag log events
+;;   - :pre-log-msg  - custom log message before body execution
+;;   - :post-log-msg - custom log message after body execution
+
+(operation-log-wrapper {:operation "processing message" :tag "smart-tag"}
+                         (do (prn "executing all the work") :return-value))
+
 ```
 
 ## Features in progress
@@ -39,16 +50,14 @@ ENABLE_LOGA=true
 Currently, user can set one tag which will be merged with the default format. It would be benefitial if user can log multiple information tags in the business flow. It allows more granular filtering in log aggreagation tools.
 
 ```clojure
-(set-tag "tracking-id" (:tracking-id msg) ;; (set-tag "tag-name" "tag-value")
-  (process-message msg)                   ;; every log will contain the `tracking-id` tag
-  (info "Finished processing message")) 
+(process-message msg)
 ```
 
 ###Log with tag - *once*
 Similar to multiple tags, but this will append the tag only to the specific log event. Next event will not include this tag.
 
 ```clojure
-(log-with-tag "Processing event" "tracking-id" (:tracking-id msg)) ;; (log-with-tag "message" "tag-name" "value")
+(set-log-tag "Processing event" "tracking-id" (:tracking-id msg)) ;; (set-log-tag "message" "tag-name" "value")
 ```
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-loga "0.2.0"
+(defproject clj-loga "0.2.1"
   :description "Library for custom log formatting and other helpers leveraging Timbre"
   :url "https://github.com/FundingCircle/clj-loga"
   :license {:name "Eclipse Public License"

--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -17,16 +17,19 @@
   `(let [operation# (:operation ~m)
          pre-log-msg# (:pre-log-msg ~m)
          post-log-msg# (:post-log-msg ~m)]
-    (info (str (or pre-log-msg# "started: ") operation#))
+    (info (str (or pre-log-msg# "started: ") (or operation# "")))
     (let [result# ~@body]
-      (info (str (or post-log-msg# "finished: ") operation#))
+      (info (str (or post-log-msg# "finished: ") (or operation# "")))
       result#)))
 
-(defmacro operation-log-wrapper
+(defmacro log-wrapper
   "Wrap function body with log before and after its execution.
   Tag is applied if present.
-  - required keys: operation
-  - optional keys: pre-log-msg, post-log-msg and tag"
+  - optional keys:
+    - tag - to tag log events
+    - pre-log-msg - custom log message before body execution
+    - :post-log-msg - custom log message after body execution
+    - :operation - descriptive name for the wrapped forms"
   [m & body]
   `(if-let [tag# (:tag ~m)]
      (set-log-tag tag# (wrap-operation-with-log ~m ~@body))
@@ -97,6 +100,8 @@
   (set-log-tag "smart-tag"
            (timbre/info "Log it tagged."))
   (timbre/error (Exception. "Something went wrong"))
-  (operation-log-wrapper {:operation "processing message" :tag "some-tag"}
+  (log-wrapper {:operation "processing message" :tag "some-tag"}
                          (do (prn "all the work happening now") "return value"))
+  (log-wrapper {:pre-log-msg "started processing kafka message" :post-log-msg "finished processing kafka message" :tag "message id"}
+               (do (prn "all the work happening now") "return value"))
   )

--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -1,17 +1,36 @@
 (ns clj-loga.core
-  (:require [taoensso.timbre :refer [errorf merge-config!] :as timbre]
-            [dire.core :refer [with-wrap-hook! with-pre-hook! with-post-hook!]]
-            [clojure.string :refer [upper-case join]]
-            [cheshire.core :refer [generate-string]]
-            [clj-time.format :as f]
-            [environ.core :refer [env]]))
+  (:require [cheshire.core :refer [generate-string]]
+            [clojure.string :refer [join upper-case]]
+            [environ.core :refer [env]]
+            [taoensso.timbre :as timbre :refer [errorf info merge-config!]]))
 
 (def ^:private ^:dynamic _tag nil)
 
-(defmacro set-tag
+(defmacro set-log-tag
   "Sets a tag, which is appended to the log event."
   [tag* & body]
-  `(binding [_tag ~tag*] ~@body))
+  `(binding [_tag ~tag*]
+     ~@body))
+
+(defmacro wrap-operation-with-log
+  [m & body]
+  `(let [operation# (:operation ~m)
+         pre-log-msg# (:pre-log-msg ~m)
+         post-log-msg# (:post-log-msg ~m)]
+    (info (str (or pre-log-msg# "started: ") operation#))
+    (let [result# ~@body]
+      (info (str (or post-log-msg# "finished: ") operation#))
+      result#)))
+
+(defmacro operation-log-wrapper
+  "Wrap function body with log before and after its execution.
+  Tag is applied if present.
+  - required keys: operation
+  - optional keys: pre-log-msg, post-log-msg and tag"
+  [m & body]
+  `(if-let [tag# (:tag ~m)]
+     (set-log-tag tag# (wrap-operation-with-log ~m ~@body))
+     (wrap-operation-with-log ~m ~@body)))
 
 (defn- get-tag []
   "Gets current _tag"
@@ -75,6 +94,9 @@
 (comment
   (setup-loga)
   (timbre/info "Log it out.")
-  (set-tag "smart-tag"
+  (set-log-tag "smart-tag"
            (timbre/info "Log it tagged."))
-  (timbre/error (Exception. "Something went wrong")))
+  (timbre/error (Exception. "Something went wrong"))
+  (operation-log-wrapper {:operation "processing message" :tag "some-tag"}
+                         (do (prn "all the work happening now") "return value"))
+  )

--- a/test/clj_loga/core_test.clj
+++ b/test/clj_loga/core_test.clj
@@ -28,30 +28,30 @@
       (set-log-tag tag (info "A tagged dummy event"))
       (is (= tag (get-log-element (latest-log-event) "tag"))))))
 
-(deftest operation-log-wrapper-test
+(deftest log-wrapper-test
   (testing "logs 2 messages around the operation"
     (reset-log-events)
-    (operation-log-wrapper {:operation "a-operation"} "result")
+    (log-wrapper {:operation "a-operation"} "result")
     (is (= 2 (count @log-events))))
   (testing "tags log messages"
     (reset-log-events)
     (let [tag "the-tag"]
-      (operation-log-wrapper {:operation "a-operation" :tag tag} "result")
+      (log-wrapper {:operation "a-operation" :tag tag} "result")
       (is (every? #(= tag %) (map #(get-log-element % "tag")  @log-events)))))
   (testing "applies custom pre-log message"
     (reset-log-events)
     (let [msg "dummy log message"]
-      (operation-log-wrapper {:operation "a-operation" :pre-log-msg msg} "result")
+      (log-wrapper {:operation "a-operation" :pre-log-msg msg} "result")
       (is (.contains (get-log-element (earliest-log-event) "message") msg))))
   (testing "applies custom post-log message"
     (reset-log-events)
     (let [msg "dummy message"]
-      (operation-log-wrapper {:operation "a-operation" :post-log-msg msg} "result")
+      (log-wrapper {:operation "a-operation" :post-log-msg msg} "result")
       (is (.contains (get-log-element (latest-log-event) "message") msg))))
   (testing "returns result of wrapped body"
     (reset-log-events)
     (let [expected-result "result"
-          result (operation-log-wrapper {:operation "a-operation"} expected-result)]
+          result (log-wrapper {:operation "a-operation"} expected-result)]
       (is (= result expected-result)))))
 
 (use-fixtures :each log-to-atom)

--- a/test/clj_loga/core_test.clj
+++ b/test/clj_loga/core_test.clj
@@ -1,8 +1,8 @@
 (ns clj-loga.core-test
   (:require [cheshire.core :refer [parse-string]]
             [clj-loga.core :refer :all]
-            [clojure.test :refer :all]
             [clj-loga.support.logging-helpers :refer :all]
+            [clojure.test :refer :all]
             [taoensso.timbre :as timbre :refer [info]]))
 
 (defn- log-to-atom [f]
@@ -12,19 +12,46 @@
 
 (def expected-default-tags [:timestamp :level :message :namespace])
 
-(defn contains-expected-tags? [event]
+(defn- contains-expected-tags? [event]
   (every? #(get (parse-string event) (name %)) expected-default-tags))
 
 (deftest setup-loga-test
   (testing "formats log event to contain desired default tags"
-    (info "A log event")
-    (is (true? (contains-expected-tags? @log-event)))))
+    (reset-log-events)
+    (info "dummy log")
+    (is (true? (contains-expected-tags? (latest-log-event))))))
 
-(deftest set-tag-test
+(deftest set-log-tag-test
   (testing "appends tag to the log event"
+    (reset-log-events)
     (let [tag "the-tag"]
-      (set-tag tag
-               (info "A tagged dummy event"))
-      (is (= tag (get (parse-string @log-event) "tag"))))))
+      (set-log-tag tag (info "A tagged dummy event"))
+      (is (= tag (get-log-element (latest-log-event) "tag"))))))
+
+(deftest operation-log-wrapper-test
+  (testing "logs 2 messages around the operation"
+    (reset-log-events)
+    (operation-log-wrapper {:operation "a-operation"} "result")
+    (is (= 2 (count @log-events))))
+  (testing "tags log messages"
+    (reset-log-events)
+    (let [tag "the-tag"]
+      (operation-log-wrapper {:operation "a-operation" :tag tag} "result")
+      (is (every? #(= tag %) (map #(get-log-element % "tag")  @log-events)))))
+  (testing "applies custom pre-log message"
+    (reset-log-events)
+    (let [msg "dummy log message"]
+      (operation-log-wrapper {:operation "a-operation" :pre-log-msg msg} "result")
+      (is (.contains (get-log-element (earliest-log-event) "message") msg))))
+  (testing "applies custom post-log message"
+    (reset-log-events)
+    (let [msg "dummy message"]
+      (operation-log-wrapper {:operation "a-operation" :post-log-msg msg} "result")
+      (is (.contains (get-log-element (latest-log-event) "message") msg))))
+  (testing "returns result of wrapped body"
+    (reset-log-events)
+    (let [expected-result "result"
+          result (operation-log-wrapper {:operation "a-operation"} expected-result)]
+      (is (= result expected-result)))))
 
 (use-fixtures :each log-to-atom)

--- a/test/clj_loga/support/logging_helpers.clj
+++ b/test/clj_loga/support/logging_helpers.clj
@@ -1,13 +1,21 @@
 (ns clj-loga.support.logging-helpers
-  (:require [taoensso.timbre :as timbre]))
+  (:require [cheshire.core :refer [parse-string]]))
 
-(def log-event (atom nil))
+(declare get-log-element)
+
+(def log-events (atom ()))
 
 (defn reset-log-events []
-  (swap! log-event (fn [_] nil)))
+  (swap! log-events (fn [_] ())))
 
 (defn- store-event [event]
-  (swap! log-event (fn [_] event)))
+  (swap! log-events (fn [logged-events] (conj logged-events event))))
+
+(defn latest-log-event []
+  (first @log-events))
+
+(defn earliest-log-event []
+  (last @log-events))
 
 (def atom-appender
   {:appenders
@@ -23,4 +31,11 @@
              formatted-output-str (output-fn data)]
          (store-event formatted-output-str)))}}})
 
+(defn get-log-element [log element]
+  (get (parse-string log) element))
 
+(comment
+  @log-events
+  (store-event "a-event")
+  (reset-log-events)
+  )


### PR DESCRIPTION
This PR is a proposal to abstract a common pattern, when we are interested in logging beginning and end of executing a specific related group of forms.
An option to tag these logs is added to minimise tangling application logic with logging code.

The PR also includes change of the core the api for setting tag to `set-log-tag`
instead of `set-tag`.