### PR TITLE
Use loga to set log level, INFO is default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ ENABLE_LOGA=true
 ;; initialize formatter
 (setup-loga)
 
+;; by default the log level is set to INFO. Lower levels will not be logged
+;; - to specify custom log level pass it as a key value in setup
+(setup-loga :level :debug)
+
 ;; easily log with timbre
 (timbre/info "Log it out.")
 

--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -86,16 +86,17 @@
 (defn- loga-enabled? []
   (= (env :enable-loga) "true"))
 
-(defn setup-loga []
+(defn setup-loga [& {:keys [level]}]
   "Initialize formatted logging."
   (if (loga-enabled?)
     (do (timbre/handle-uncaught-jvm-exceptions!)
         (merge-config! {:output-fn output-fn
-                        :timestamp-opts iso-timestamp-opts}))
+                        :timestamp-opts iso-timestamp-opts
+                        :level (or level :info)}))
     (timbre/info "Skipping custom log formatter.")))
 
 (comment
-  (setup-loga)
+  (setup-loga :level :info)
   (timbre/info "Log it out.")
   (set-log-tag
    "smart-tag"


### PR DESCRIPTION
Give user easier control of setting a log level in application.

The default value is INFO as we are not typically interested in lower levels.