### PR TITLE
Update README - Timbre version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # clj-loga [![Circle CI](https://circleci.com/gh/FundingCircle/clj-loga/tree/master.svg?style=svg)](https://circleci.com/gh/FundingCircle/clj-loga/tree/master)
 
-Library for custom log formatting and other helpers leveraging Timbre.
+Library for custom log formatting and other helpers leveraging [Timbre](https://github.com/ptaoussanis/timbre/).
+
+Supports logging with timbre >= 4.1.1.
 
 ## Usage
 


### PR DESCRIPTION
Its important that users know that they must be using timbre version >= 4.1.1.

**Earlier versions will break.**