### PR TITLE
Obfuscate sensitive keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ ENABLE_LOGA=true
 ;; - to specify custom log level pass it as a key value in setup
 (setup-loga :level :debug)
 
+;; obfuscate sensitive keys
+(setup-loga :obfuscate [:password])
+
+;; log worry-free
+(timbre/info "Log event with params"
+  {:password "secret" :bar "baz" :sub {:password "secret" :foo "bar"}})
+;; =>
+;; {"level":"INFO","timestamp":"2016-01-13T10:31:17.126Z","namespace":"clj-loga.core",
+;; "message":"Log event with params {:password \"[FILTERED]\", :bar \"baz\", :sub {:password \"[FILTERED]\", :foo \"bar\"}}"}"\"}\"}"}
+
 ;; easily log with timbre
 (timbre/info "Log it out.")
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-loga "0.2.3"
+(defproject clj-loga "0.3.0"
   :description "Library for custom log formatting and other helpers leveraging Timbre"
   :url "https://github.com/FundingCircle/clj-loga"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Some logged data might contain sensitive information, which should not leak into logs. This PR is an attempt to solve this as following:

```clojure
;; specify sensitive keys
(setup-loga :obfuscate [:password])

;; log worry-free
(timbre/info "Log event with params"
  {:password "secret" :bar "baz" :sub {:password "secret" :foo "bar"}})
;; =>
;; {"level":"INFO","timestamp":"2016-01-13T10:31:17.126Z","namespace":"clj-loga.core","message":"Log event with params {:password \"[FILTERED]\", :bar \"baz\", :sub {:password \"[FILTERED]\", :foo \"bar\"}}"}
```

Environmental var must be setup `ENABLE_LOGA=true` so timbre can pick up the config.

Thanks @nachomdo for suggesting this enhancement in issue https://github.com/FundingCircle/clj-loga/issues/12
