### PR TITLE
Using the ns of the invocation to setup-loga to build a default ns pa…

### DIFF
--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -117,10 +117,16 @@
                           (let [meta-args (-> (meta function) select-loga-keys (format-pre-log-msg args))]
                             (log-wrapper meta-args (apply f args)))))))
 
+(defn- current-ns-pattern []
+  (let [components (clojure.string/split (str (ns-name *ns*)) #"\.")
+        components(if (= 1 (count components)) components (drop-last components))
+        components (clojure.string/join "\\." components)]
+    (str "^" components "(\\..+)*$")))
+
 (defn setup-loga
   "Initialize formatted logging."
   [& {:keys [level namespaces obfuscate]
-                     :or {level :info namespaces [] obfuscate []}}]
+      :or {level :info namespaces [(current-ns-pattern)] obfuscate []}}]
   (if (loga-enabled?)
     (do (timbre/handle-uncaught-jvm-exceptions!)
         (set-loga-hooks namespaces)

--- a/src/clj_loga/hooks.clj
+++ b/src/clj_loga/hooks.clj
@@ -3,7 +3,7 @@
 
 (defn- filter-namespace
   [item]
-  (filter #(re-find (re-pattern item) (str %)) (all-ns)))
+  (filter #(re-find (re-pattern item) (str (ns-name %))) (all-ns)))
 
 (defn get-namespaces-from-list
   "Gets an expanded list of namespaces from a list
@@ -34,4 +34,3 @@
 
 (defn format-pre-log-msg [meta args]
   (assoc meta :pre-log-msg (apply format (:pre-log-msg meta) args)))
-

--- a/test/clj_loga/core_test.clj
+++ b/test/clj_loga/core_test.clj
@@ -61,4 +61,19 @@
           result (log-wrapper {:operation "a-operation"} expected-result)]
       (is (= result expected-result)))))
 
+(deftest current-ns-pattern-test
+  (let [current-ns-pattern #'clj-loga.core/current-ns-pattern
+        ;; test cases
+        current-ns-name (-> *ns* ns-name str)
+        sub-current-ns-name (str current-ns-name ".foo.bar")
+        incorrect-ns-name (str "prefix." sub-current-ns-name)]
+
+    (letfn [(matches [ns should-pass]
+              (is ((if should-pass identity not)
+                   (re-matches (re-pattern (current-ns-pattern)) ns))))]
+
+      (matches current-ns-name true)
+      (matches sub-current-ns-name true)
+      (matches incorrect-ns-name false))))
+
 (use-fixtures :each log-to-atom)


### PR DESCRIPTION
if (setup-loga) invoked in ns a.b.c, /^a.b(\..+)*$/ will be used as the default pattern.
if the ns has a single component (e.g. myns) /^myns(\..+)*$/ will be used.