### PR TITLE
Made loga enabled by default, env variable to disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased][unreleased]
-### Changed
-- Add a new arity to `make-widget-async` to provide a different widget shape.
+## 0.4.1 - 2016-02-22
 
-## [0.1.1] - 2015-12-21
-### Changed
-- Documentation on how to make the widgets.
+Changed:
+- ENABLE_LOGA environment variable is no longer needed for loga to work.
 
-### Removed
-- `make-widget-sync` - we're all async, all the time.
+Added:
+- DISABLE_LOGA environment variable can be used to disbale loga when it's set to `true`.
 
-### Fixed
-- Fixed widget maker to keep working when daylight savings switches over.
-
-## 0.1.0 - 2015-12-21
-### Added
-- Files from the new template.
-- Widget maker public API - `make-widget-sync`.
-
-[unreleased]: https://github.com/your-name/clj-loga/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/your-name/clj-loga/compare/0.1.0...0.1.1

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-loga "0.4.0"
+(defproject clj-loga "0.4.1"
   :description "Library for custom log formatting and other helpers leveraging Timbre"
   :url "https://github.com/FundingCircle/clj-loga"
   :license {:name "Eclipse Public License"
@@ -11,5 +11,4 @@
                  [robert/hooke "1.3.0"]                                          ;; Hooks
                  ]
   :plugins [[lein-cljfmt  "0.3.0"]
-            [lein-environ "1.0.1"]]
-  :profiles {:test {:env {:enable-loga "true"}}})
+            [lein-environ "1.0.1"]])

--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -97,7 +97,7 @@
         generate-string)))
 
 (defn- loga-enabled? []
-  (= (env :enable-loga) "true"))
+  (not (= (:disable-loga env) "true")))
 
 (defn obfuscate-key [m key-to-obfuscate]
   (if (contains? m key-to-obfuscate)


### PR DESCRIPTION
Small change - environment variable step seems to be completely redundant and easy to miss when loga is being setup. Once the loga is added to code, it should work without a need of ENV var to be set, however it still should be possible to disable it if needed.