### PR TITLE
Timbre wrappers for direct logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@ All notable changes to this project will be documented in this file. This change
 
 ## [0.5.0] - 27/03/2016
 ###Added
-Enabled logging using loga directly providing wrappers around Timbre's logging macros. Supported log levels are: `:log, :trace, :debug, :info, :warn, :error, :fatal, :report`
+1. Enabled logging using loga directly providing wrappers around Timbre's logging macros. Supported log levels are: `:log, :trace, :debug, :info, :warn, :error, :fatal, :report`
+0. Bump up Timbre version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,6 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased][unreleased]
-### Changed
-- Add a new arity to `make-widget-async` to provide a different widget shape.
-
-## [0.1.1] - 2015-12-21
-### Changed
-- Documentation on how to make the widgets.
-
-### Removed
-- `make-widget-sync` - we're all async, all the time.
-
-### Fixed
-- Fixed widget maker to keep working when daylight savings switches over.
-
-## 0.1.0 - 2015-12-21
-### Added
-- Files from the new template.
-- Widget maker public API - `make-widget-sync`.
-
-[unreleased]: https://github.com/your-name/clj-loga/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/your-name/clj-loga/compare/0.1.0...0.1.1
+## [0.5.0] - 27/03/2016
+###Added
+Enabled logging using loga directly providing wrappers around Timbre's logging macros. Supported log levels are: `:log, :trace, :debug, :info, :warn, :error, :fatal, :report`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # clj-loga [![Circle CI](https://circleci.com/gh/FundingCircle/clj-loga/tree/master.svg?style=svg)](https://circleci.com/gh/FundingCircle/clj-loga/tree/master)
 
-Library for custom log formatting and other helpers leveraging [Timbre](https://github.com/ptaoussanis/timbre/).
+Standing on the shoulders of great logging library [Timbre](https://github.com/ptaoussanis/timbre/), loga extends Timbre's functionality with applying following features:
+- custom json log appender
+- tagging log messages
+- obfuscation
+
+Loga also provides wrappers around Timbre's logging macros to allow logging directly from the library. It removes the need to use timbre in the application directly, thus reduces risk of conflicts between version of Timbre used in Logs and in the application.
 
 Supports logging with timbre >= 4.1.1.
 
@@ -20,7 +25,7 @@ ENABLE_LOGA=true
 **Repl**
 
 ```clojure
-(require '[clj-loga.core :refer [setup-loga set-log-tag log-wrapper]])
+(require '[clj-loga.core :as loga :refer [setup-loga set-log-tag log-wrapper]])
 
 ;; initialize formatter
 (setup-loga)
@@ -28,6 +33,11 @@ ENABLE_LOGA=true
 ;; by default the log level is set to INFO. Lower levels will not be logged
 ;; - to specify custom log level pass it as a key value in setup
 (setup-loga :level :debug)
+
+;; Logging using Loga
+;; supported levels:
+;;   - log trace debug info warn error fatal
+(loga/info "my log message")
 
 ;; obfuscate sensitive keys
 (setup-loga :obfuscate [:password])
@@ -108,7 +118,6 @@ As an alternative, it is possible to use function metadata to log instead of clu
 
 ;; narrow down target function search by specifying the namespaces
 (setup-loga :level :debug :namespaces ["my-ns.*" "another-ns.core"])
-
 ```
 
 ## Features in progress

--- a/README.md
+++ b/README.md
@@ -1,28 +1,29 @@
 # clj-loga [![Circle CI](https://circleci.com/gh/FundingCircle/clj-loga/tree/master.svg?style=svg)](https://circleci.com/gh/FundingCircle/clj-loga/tree/master)
 
-Standing on the shoulders of great logging library [Timbre](https://github.com/ptaoussanis/timbre/), loga extends Timbre's functionality with applying following features:
-- custom json log appender
-- tagging log messages
-- obfuscation
+Standing on the shoulders of the great logging library [Timbre](https://github.com/ptaoussanis/timbre/), loga extends Timbre's functionality by applying following features:
+- custom json log appender - allows convenient way of parsing logs for log aggregators
+- tagging log messages - allows to aggregate and track log events across multiple services based on the log
+- obfuscation - prevent sensitive data to be readable in logs
 
-Loga also provides wrappers around Timbre's logging macros to allow logging directly from the library. It removes the need to use timbre in the application directly, thus reduces risk of conflicts between version of Timbre used in Logs and in the application.
+Loga also provides wrappers around Timbre's logging macros to allow logging directly from the library. It removes the need to use Timbre in the application directly, thus reducing risk of conflicts between version of Timbre used in Logs and in the application.
 
-Supports logging with timbre >= 4.1.1.
+Supports Timbre >= 4.1.1.
 
 ## Usage
 
-**Installation**
+### Installation
 
 [![Clojars Project](http://clojars.org/clj-loga/latest-version.svg)](http://clojars.org/clj-loga)
 
-**Environment**
+### Environment
+Loga features are mainly to benefit logging aggregators and its use makes logs less readable and inconvenient in development. Hence, it is required to allow loga explicitly.
 
 ```bash
-#export env variable to apply formatting
+# export env variable to apply formatting
 ENABLE_LOGA=true
 ```
 
-**Repl**
+### REPL
 
 ```clojure
 (require '[clj-loga.core :as loga :refer [setup-loga set-log-tag log-wrapper]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-loga "0.4.0"
+(defproject clj-loga "0.5.0"
   :description "Library for custom log formatting and other helpers leveraging Timbre"
   :url "https://github.com/FundingCircle/clj-loga"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,11 @@
   :license {:name "Eclipse Public License"
             :url "http://opensource.org/licenses/BSD-3-Clause"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [cheshire "5.5.0"]                                              ;; JSON/JSONB encoding/decoding
-                 [clj-time "0.11.0"]                                             ;; Joda Time wrapper
-                 [com.taoensso/timbre "4.1.1"]                                   ;; Logging and profiling
-                 [environ "0.5.0"]                                               ;; Environment variables
-                 [robert/hooke "1.3.0"]                                          ;; Hooks
+                 [cheshire "5.5.0"]                    ;; JSON/JSONB encoding/decoding
+                 [clj-time "0.11.0"]                   ;; Joda Time wrapper
+                 [com.taoensso/timbre "4.3.1"]         ;; Logging and profiling
+                 [environ "0.5.0"]                     ;; Environment variables
+                 [robert/hooke "1.3.0"]                ;; Hooks
                  ]
   :plugins [[lein-cljfmt  "0.3.0"]
             [lein-environ "1.0.1"]]

--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -11,7 +11,7 @@
              [walk :refer [postwalk]]]
             [environ.core :refer [env]]
             [robert.hooke :refer [add-hook]]
-            [taoensso.timbre :as timbre :refer [errorf info merge-config!]]))
+            [taoensso.timbre :as timbre :refer [merge-config!]]))
 
 (def ^:private ^:dynamic _tag nil)
 
@@ -29,10 +29,10 @@
          pre-log-msg# (:pre-log-msg ~m)
          post-log-msg# (:post-log-msg ~m)]
      (if (fn? pre-log-msg#)
-       (do (pre-log-msg#) (info (or operation# "")))
-       (info (str (or pre-log-msg# "started: ") (or operation# ""))))
+       (do (pre-log-msg#) (timbre/info (or operation# "")))
+       (timbre/info (str (or pre-log-msg# "started: ") (or operation# ""))))
      (let [result# ~@body]
-       (info (str (or post-log-msg# "finished: ") (or operation# "")))
+       (timbre/info (str (or post-log-msg# "finished: ") (or operation# "")))
        result#)))
 
 (defmacro log-wrapper
@@ -84,7 +84,7 @@
    :timezone (java.util.TimeZone/getDefault)})
 
 (defn- exception-handler [throwable ^Thread thread]
-  (errorf throwable "Uncaught exception on thread: %s"
+  (timbre/errorf throwable "Uncaught exception on thread: %s"
           (.getName thread)))
 
 (defn- output-fn
@@ -142,7 +142,37 @@
                         :level level}))
     (timbre/info "Skipping custom log formatter.")))
 
+(defmacro log
+  [& args]
+  `(timbre/log ~@args))
+
+(defmacro trace
+  [& args]
+  `(timbre/trace ~@args))
+
+(defmacro debug
+  [& args]
+  `(timbre/debug ~@args))
+
+(defmacro info
+  [& args]
+  `(timbre/info ~@args))
+
+(defmacro warn
+  [& args]
+  `(timbre/warn ~@args))
+
+(defmacro error
+  [& args]
+  `(timbre/error ~@args))
+
+(defmacro fatal
+  [& args]
+  `(timbre/fatal ~@args))
+
 (comment
+  (log :info "message")
+  (trace "message")
   (setup-loga :obfuscate [:password] :level :debug)
   (setup-loga :level :debug)
   (timbre/info "Log event with params" {:password "secret" :bar "baz" :sub {:password "secret" :foo "bar"}})

--- a/test/clj_loga/support/logging_helpers.clj
+++ b/test/clj_loga/support/logging_helpers.clj
@@ -1,5 +1,6 @@
 (ns clj-loga.support.logging-helpers
-  (:require [cheshire.core :refer [parse-string]]))
+  (:require [cheshire.core :refer [parse-string]]
+            [clojure.walk :refer [keywordize-keys]]))
 
 (declare get-log-element)
 
@@ -14,6 +15,9 @@
 (defn latest-log-event []
   (first @log-events))
 
+(defn latest-log-event-map []
+  (some-> (latest-log-event) parse-string keywordize-keys))
+
 (defn earliest-log-event []
   (last @log-events))
 
@@ -22,7 +26,6 @@
    {:atom-appender
     {:enabled? true
      :async? false
-     :min-level nil
      :rate-limit [[1 250] [10 5000]]
      :output-fn :inherit
      :fn
@@ -33,6 +36,10 @@
 
 (defn get-log-element [log element]
   (get (parse-string log) element))
+
+(defn uuid
+  []
+  (.toString (java.util.UUID/randomUUID)))
 
 (comment
   @log-events


### PR DESCRIPTION
Add wrappers around Timbre's logging macros to allow logging directly from the library as following:

```clojure
(require '[clj-loga.core :as loga])
(loga/info "my log message")
```

Supported log levels:
`:log :trace :debug :info :warn :error :fatal`