### PR TITLE
Automatically tag and deploy artifacts to Clojars

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,8 @@
+deployment:
+  clojars:
+    branch: master
+    owner: FundingCircle
+    commands:
+      - git config --global user.email "circleci@circleci.com"
+      - git config --global user.name "CircleCI"
+      - lein do deploy, vcs tag --no-sign :prefix "v", vcs push

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,13 @@
                  [environ "0.5.0"]                     ;; Environment variables
                  [robert/hooke "1.3.0"]                ;; Hooks
                  ]
+
+  :repositories [["releases"
+                  {:url "https://clojars.org/repo"
+                   :sign-releases false
+                   :username [:gpg :env/clojars_user]
+                   :password [:gpg :env/clojars_password]}]]
+
   :plugins [[lein-cljfmt  "0.3.0"]
             [lein-environ "1.0.1"]]
   :profiles {:test {:env {:enable-loga "true"}}})


### PR DESCRIPTION
💁  These changes automatically:
* build and deploy artifacts to Clojars; and
* `git tag` the release in and push it to GitHub.