### PR TITLE
Fallback to default output fn if failure occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,6 @@ All notable changes to this project will be documented in this file. This change
 
 ## [0.6.0] - 25/5/2016
 1. Log exception message to message if no message was supplied.
+
+## [0.6.1] - 07/6/2016
+1. Fallback to default timbre output function if exception thrown during processing logs.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-loga "0.6.0"
+(defproject clj-loga "0.6.1"
   :description "Library for custom log formatting and other helpers leveraging Timbre"
   :url "https://github.com/FundingCircle/clj-loga"
   :license {:name "BSD 3-Clause License"

--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -66,7 +66,7 @@
 (defn- exception-map
   [m e]
   (let [error-message (str (.toString e))]
-   (if (nil? (:message m))
+   (if (empty? (:message m))
     {:message error-message}
     {:exception-message error-message})))
 

--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -91,9 +91,9 @@
 
 (defn- format-log-event
   [{:keys [level ?err_ vargs_ msg_ ?ns-str hostname_ timestamp_ ?line]}]
-  {:timestamp @timestamp_
+  {:timestamp (force timestamp_)
    :level (upper-case (name level))
-   :message @msg_
+   :message (str (force msg_))
    :namespace ?ns-str})
 
 (def ^:private iso-timestamp-opts
@@ -116,7 +116,8 @@
             append-tag
             generate-string)
        (catch Exception e
-         (format "Unable to process log event due to error %s. Log: %s" (.getMessage e) formatted-log))))))
+         (println (format "Unable to process log event. Falling back to default formatting; cause: %s, log: %s" (.getMessage e) formatted-log))
+         (timbre/default-output-fn data))))))
 
 (defn- loga-enabled? []
   (= (env :enable-loga) "true"))


### PR DESCRIPTION
Use Timbre's default output function, when exception occurs during processing log even.