### PR TITLE
Update timbre to version 4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ All notable changes to this project will be documented in this file. This change
 1. Add support for `ex-info`. `ex-data` are accessible on `:exception-data` key as part of the log message.
 2. Add error message to the exception message is accessible on `exception-message` key as part of the log message.
 
-## [0.5.3] - 18/5/2016
+## [0.5.3] - 18/05/2016
 1. Handle exception in processing log event.
 
-## [0.6.0] - 25/5/2016
+## [0.6.0] - 25/05/2016
 1. Log exception message to message if no message was supplied.
 
-## [0.6.1] - 07/6/2016
+## [0.6.1] - 07/06/2016
 1. Fallback to default timbre output function if exception thrown during processing logs.
+
+## [0.7.0] - 28/02/2017
+1. Update dependencies. 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Standing on the shoulders of the great logging library [Timbre](https://github.c
 
 Loga also provides wrappers around Timbre's logging macros to allow logging directly from the library. It removes the need to use Timbre in the application directly, thus reducing risk of conflicts between version of Timbre used in Logs and in the application.
 
-Supports Timbre >= 4.1.1.
+## Warning
+This library depends on Timbre `[com.taoensso/timbre "4.8.0"]`. If Timbre is also required in your project, make sure they are compatible.
+
+Supports `[com.taoensso/timbre "4.4.0"]` and higher version.
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,12 @@
-(defproject clj-loga "0.6.1"
+(defproject clj-loga "0.7.1"
   :description "Library for custom log formatting and other helpers leveraging Timbre"
   :url "https://github.com/FundingCircle/clj-loga"
   :license {:name "BSD 3-Clause License"
             :url "http://opensource.org/licenses/BSD-3-Clause"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [cheshire "5.5.0"]                    ;; JSON/JSONB encoding/decoding
-                 [clj-time "0.11.0"]                   ;; Joda Time wrapper
-                 [com.taoensso/timbre "4.3.1"]         ;; Logging and profiling
-                 [environ "0.5.0"]                     ;; Environment variables
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [cheshire "5.7.0"]                    ;; JSON/JSONB encoding/decoding
+                 [com.taoensso/timbre "4.8.0"]         ;; Logging and profiling
+                 [environ "1.1.0"]                     ;; Environment variables
                  [robert/hooke "1.3.0"]                ;; Hooks
                  ]
 
@@ -18,5 +17,5 @@
                    :password [:gpg :env/clojars_password]}]]
 
   :plugins [[lein-cljfmt  "0.3.0"]
-            [lein-environ "1.0.1"]]
+            [lein-environ "1.1.0"]]
   :profiles {:test {:env {:enable-loga "true"}}})

--- a/src/clj_loga/core.clj
+++ b/src/clj_loga/core.clj
@@ -152,14 +152,14 @@
                   (log-wrapper meta-args (apply f args)))))))
 
 (defn setup-loga
-  "Initialize formatted logging."
+  "Initialise formatted logging."
   [& {:keys [level namespaces obfuscate]
       :or {level :info namespaces [:all] obfuscate []}}]
   (if (loga-enabled?)
     (do (timbre/handle-uncaught-jvm-exceptions!)
         (set-loga-hooks namespaces)
-        (merge-config! {:middleware [(fn [{:keys [vargs_] :as data}]
-                                       (assoc data :vargs_ (delay (obfuscate-data @vargs_ obfuscate))))]
+        (merge-config! {:middleware [(fn [{:keys [vargs] :as data}]
+                                       (assoc data :vargs (obfuscate-data vargs obfuscate)))]
                         :output-fn output-fn
                         :timestamp-opts iso-timestamp-opts
                         :level level}))


### PR DESCRIPTION
Fix obfuscation due to breaking changes in timbre v4.5.0:
https://github.com/ptaoussanis/timbre/blob/master/CHANGELOG.md#v450--2016-jun-26

Removes not used clj-time dependency.