### PR TITLE
Update timbre, bump version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://opensource.org/licenses/BSD-3-Clause"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [cheshire "5.7.0"]                    ;; JSON/JSONB encoding/decoding
-                 [com.taoensso/timbre "4.8.0"]         ;; Logging and profiling
+                 [com.taoensso/timbre "4.10.0"]         ;; Logging and profiling
                  [environ "1.1.0"]                     ;; Environment variables
                  [robert/hooke "1.3.0"]                ;; Hooks
                  ]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-loga "0.7.1"
+(defproject clj-loga "0.7.2"
   :description "Library for custom log formatting and other helpers leveraging Timbre"
   :url "https://github.com/FundingCircle/clj-loga"
   :license {:name "BSD 3-Clause License"


### PR DESCRIPTION
The old version of `timbre` prevents exits when an unhandled exception is thrown.