### PR TITLE
Fix Clojars deployment 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ workflows:
   deploy_clojars:
     jobs:
       - clojars:
+          context: clojars-deploy
           filters:
             branches:
               only: master

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   :repositories [["releases"
                   {:url "https://clojars.org/repo"
                    :sign-releases false
-                   :username [:gpg :env/clojars_user]
+                   :username [:gpg :env/clojars_username]
                    :password [:gpg :env/clojars_password]}]]
 
   :plugins [[lein-cljfmt  "0.3.0"]


### PR DESCRIPTION
This PR is intended to fix deployments to Clojars by reading the proper credentials from the org context dedicated to it. This approach mimics the one followed in Jackdaw which seems to be working 