### PR TITLE
Bump up version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-loga "0.7.2"
+(defproject clj-loga "0.7.3"
   :description "Library for custom log formatting and other helpers leveraging Timbre"
   :url "https://github.com/FundingCircle/clj-loga"
   :license {:name "BSD 3-Clause License"


### PR DESCRIPTION
Authentication issues have been solved. Now we cannot redeploy an existing version so we need to bump up the project version

```
Wrote /home/circleci/project/pom.xml
Sending clj-loga/clj-loga/0.7.2/clj-loga-0.7.2.jar (9k)
    to https://clojars.org/repo/
Sending clj-loga/clj-loga/0.7.2/clj-loga-0.7.2.pom (3k)
    to https://clojars.org/repo/
Retrieving clj-loga/clj-loga/maven-metadata.xml (1k)
    from https://clojars.org/repo/
Sending clj-loga/clj-loga/maven-metadata.xml (1k)
    to https://clojars.org/repo/
Could not transfer metadata clj-loga:clj-loga/maven-metadata.xml from/to releases (https://clojars.org/repo): Access denied to: https://clojars.org/repo/clj-loga/clj-loga/maven-metadata.xml, ReasonPhrase: Forbidden - redeploying non-snapshots is not allowed (see https://git.io/v1IAs).
Failed to deploy metadata: Could not transfer metadata clj-loga:clj-loga/maven-metadata.xml from/to releases (https://clojars.org/repo): Access denied to: https://clojars.org/repo/clj-loga/clj-loga/maven-metadata.xml, ReasonPhrase: Forbidden - redeploying non-snapshots is not allowed (see https://git.io/v1IAs).

Exited with code exit status 1
```